### PR TITLE
feat(docs): add m2m interaction policy

### DIFF
--- a/docs/m2m_interaction_policy.md
+++ b/docs/m2m_interaction_policy.md
@@ -1,0 +1,75 @@
+# LLM to LLM Interaction Policy
+
+## 1. Introduction
+
+This document outlines the policy and guidelines for interactions between Large Language Models (LLMs) and other autonomous agents. The purpose of this policy is to ensure that all machine-to-machine (M2M) interactions are clear, efficient, secure, and robust.
+
+## 2. Core Principles
+
+All LLM interactions should adhere to the following core principles:
+
+*   **Clarity and Precision**: Communication should be unambiguous and precise. Use of structured data formats is required.
+*   **Efficiency**: Interactions should be designed to minimize computational resources and latency. Avoid unnecessary verbosity.
+*   **Verifiability**: All information exchanged should be verifiable. When presenting information, an LLM should provide its sources or a method to verify the information.
+*   **Security**: All interactions must be secure. This includes authentication, authorization, and protection against malicious inputs.
+*   **Graceful Degradation and Error Handling**: LLMs should be designed to handle errors gracefully and provide clear error messages.
+
+## 3. Interaction Protocols
+
+A standardized protocol shall be used for all M2M interactions.
+
+### Request/Response Format
+
+All interactions should use a JSON-based request/response format.
+
+**Request:**
+```json
+{
+  "sender_id": "string",
+  "receiver_id": "string",
+  "task_id": "string",
+  "timestamp": "ISO 8601 string",
+  "payload": {
+    "task_type": "string",
+    "data": {}
+  }
+}
+```
+
+**Response:**
+```json
+{
+  "sender_id": "string",
+  "receiver_id": "string",
+  "task_id": "string",
+  "timestamp": "ISO 8601 string",
+  "status": "success|error",
+  "payload": {
+    "data": {},
+    "error": {
+      "code": "string",
+      "message": "string"
+    }
+  }
+}
+```
+
+## 4. Data Formatting
+
+*   **Structured Data**: All data exchanged between LLMs must be in a structured format, preferably JSON.
+*   **Schema Definition**: A clear schema should be defined for each `task_type` to ensure that both the sender and receiver have a common understanding of the data being exchanged.
+
+## 5. Security Considerations
+
+*   **Authentication and Authorization**: Each LLM must be authenticated before it can interact with another LLM. API keys, OAuth tokens, or other standard authentication methods should be used.
+*   **Input Sanitization**: All incoming data must be sanitized to prevent injection attacks or other malicious inputs.
+*   **Data Encryption**: All data transmitted between LLMs should be encrypted using industry-standard encryption protocols like TLS.
+
+## 6. Error Handling
+
+*   **Standardized Error Codes**: A set of standardized error codes should be used to indicate the nature of an error.
+*   **Clear Error Messages**: Error messages should be clear, concise, and provide enough information for debugging.
+
+## 7. Versioning
+
+APIs and interaction protocols should be versioned. When a breaking change is introduced, a new version of the protocol should be released to ensure backward compatibility. Versioning should be handled through the API endpoint (e.g., `/api/v2/...`).


### PR DESCRIPTION
Adds a new document outlining the guidelines for machine-to-machine (M2M) interactions between LLMs.

This policy covers core principles, interaction protocols, data formatting, security, error handling, and versioning.