### PR TITLE
Add C++ unit and native BDD test suite under test/

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,37 @@
+cmake_minimum_required(VERSION 3.16)
+project(prismquanta_tests LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+enable_testing()
+
+set(TEST_COMMON_SOURCES
+    test_main.cpp
+    ../src/core_engine.cpp
+    ../src/model_backend.cpp
+    ../src/QuantaEthos/ethics_logic.cpp
+)
+
+set(TEST_INCLUDE_DIRS
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}/../include
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src/QuantaEthos
+)
+
+add_executable(prismquanta_unit_tests
+    ${TEST_COMMON_SOURCES}
+    unit/test_ethics_logic.cpp
+    unit/test_model_backend.cpp
+    unit/test_core_engine.cpp
+)
+target_include_directories(prismquanta_unit_tests PRIVATE ${TEST_INCLUDE_DIRS})
+add_test(NAME prismquanta_unit_tests COMMAND prismquanta_unit_tests)
+
+add_executable(prismquanta_native_bdd_tests
+    ${TEST_COMMON_SOURCES}
+    bdd/test_core_engine_bdd.cpp
+)
+target_include_directories(prismquanta_native_bdd_tests PRIVATE ${TEST_INCLUDE_DIRS})
+add_test(NAME prismquanta_native_bdd_tests COMMAND prismquanta_native_bdd_tests)

--- a/test/bdd/test_core_engine_bdd.cpp
+++ b/test/bdd/test_core_engine_bdd.cpp
@@ -1,0 +1,37 @@
+#include <string>
+
+#include "core_engine.h"
+#include "native_bdd.h"
+
+SCENARIO(core_engine_generates_ethically_checked_response) {
+    GIVEN("an operator prompt asking for a summary");
+    STEP_USED(given_step);
+
+    CoreEngine engine;
+
+    WHEN("the prompt is processed by the core engine");
+    STEP_USED(when_step);
+    const std::string response = engine.generate_response("summarize project status");
+
+    THEN("the response is run through ethical and trustworthiness checks");
+    STEP_USED(then_step);
+    THEN_EQ(
+        "Checked: Model output for: Ethical prompt for: summarize project status",
+        response
+    );
+}
+
+SCENARIO(core_engine_handles_empty_prompt_without_crashing) {
+    GIVEN("an empty user prompt");
+    STEP_USED(given_step);
+
+    CoreEngine engine;
+
+    WHEN("the empty prompt is processed");
+    STEP_USED(when_step);
+    const std::string response = engine.generate_response("");
+
+    THEN("a checked model response is still returned");
+    STEP_USED(then_step);
+    THEN_EQ("Checked: Model output for: Ethical prompt for: ", response);
+}

--- a/test/native_bdd.h
+++ b/test/native_bdd.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <sstream>
+#include <string>
+
+#include "test_framework.h"
+
+#define SCENARIO(NAME) TEST_CASE(NAME)
+#define GIVEN(DESC) const std::string given_step = std::string("GIVEN: ") + (DESC)
+#define WHEN(DESC) const std::string when_step = std::string("WHEN: ") + (DESC)
+#define THEN(DESC) const std::string then_step = std::string("THEN: ") + (DESC)
+
+#define STEP_USED(STEP) ASSERT_TRUE(!(STEP).empty())
+
+#define THEN_EQ(EXPECTED, ACTUAL) ASSERT_EQ((EXPECTED), (ACTUAL))
+#define THEN_TRUE(EXPR) ASSERT_TRUE((EXPR))

--- a/test/test_framework.h
+++ b/test/test_framework.h
@@ -1,0 +1,86 @@
+#pragma once
+
+#include <cmath>
+#include <functional>
+#include <iostream>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+class TestFailure : public std::runtime_error {
+public:
+    explicit TestFailure(const std::string& message)
+        : std::runtime_error(message) {}
+};
+
+struct TestCase {
+    std::string name;
+    std::function<void()> fn;
+};
+
+inline std::vector<TestCase>& registry() {
+    static std::vector<TestCase> tests;
+    return tests;
+}
+
+inline int register_test(const std::string& name, std::function<void()> fn) {
+    registry().push_back({name, std::move(fn)});
+    return 0;
+}
+
+#define TEST_CASE(NAME) \
+    void NAME(); \
+    static int NAME##_registered = register_test(#NAME, NAME); \
+    void NAME()
+
+#define ASSERT_TRUE(EXPR) \
+    do { \
+        if (!(EXPR)) { \
+            std::ostringstream oss; \
+            oss << "Expected true: " << #EXPR << " at " << __FILE__ << ":" << __LINE__; \
+            throw TestFailure(oss.str()); \
+        } \
+    } while (false)
+
+#define ASSERT_EQ(EXPECTED, ACTUAL) \
+    do { \
+        const auto expected_value = (EXPECTED); \
+        const auto actual_value = (ACTUAL); \
+        if (!(expected_value == actual_value)) { \
+            std::ostringstream oss; \
+            oss << "Assertion failed at " << __FILE__ << ":" << __LINE__ \
+                << " expected [" << expected_value << "] but got [" << actual_value << "]"; \
+            throw TestFailure(oss.str()); \
+        } \
+    } while (false)
+
+#define ASSERT_NEAR(EXPECTED, ACTUAL, EPSILON) \
+    do { \
+        const auto expected_value = static_cast<double>(EXPECTED); \
+        const auto actual_value = static_cast<double>(ACTUAL); \
+        const auto epsilon_value = static_cast<double>(EPSILON); \
+        if (std::fabs(expected_value - actual_value) > epsilon_value) { \
+            std::ostringstream oss; \
+            oss << "Assertion failed at " << __FILE__ << ":" << __LINE__ \
+                << " expected [" << expected_value << "] got [" << actual_value << "] with epsilon [" << epsilon_value << "]"; \
+            throw TestFailure(oss.str()); \
+        } \
+    } while (false)
+
+inline int run_all_tests() {
+    int failures = 0;
+
+    for (const auto& test : registry()) {
+        try {
+            test.fn();
+            std::cout << "[PASS] " << test.name << '\n';
+        } catch (const std::exception& ex) {
+            ++failures;
+            std::cerr << "[FAIL] " << test.name << " -- " << ex.what() << '\n';
+        }
+    }
+
+    std::cout << "Executed " << registry().size() << " tests, failures: " << failures << '\n';
+    return failures == 0 ? 0 : 1;
+}

--- a/test/test_main.cpp
+++ b/test/test_main.cpp
@@ -1,0 +1,5 @@
+#include "test_framework.h"
+
+int main() {
+    return run_all_tests();
+}

--- a/test/unit/test_core_engine.cpp
+++ b/test/unit/test_core_engine.cpp
@@ -1,0 +1,20 @@
+#include <string>
+
+#include "core_engine.h"
+#include "test_framework.h"
+
+TEST_CASE(generate_response_applies_trustworthiness_wrapper) {
+    CoreEngine engine;
+    ASSERT_EQ(
+        "Checked: Model output for: Ethical prompt for: plan a task",
+        engine.generate_response("plan a task")
+    );
+}
+
+TEST_CASE(generate_response_is_deterministic_for_same_prompt) {
+    CoreEngine engine;
+    const std::string first = engine.generate_response("consistency check");
+    const std::string second = engine.generate_response("consistency check");
+
+    ASSERT_EQ(first, second);
+}

--- a/test/unit/test_ethics_logic.cpp
+++ b/test/unit/test_ethics_logic.cpp
@@ -1,0 +1,20 @@
+#include <string>
+
+#include "ethics_logic.h"
+#include "test_framework.h"
+
+TEST_CASE(makeEthicalPrompt_prefixes_user_input) {
+    ASSERT_EQ("Ethical prompt for: explain the weather", makeEthicalPrompt("explain the weather"));
+}
+
+TEST_CASE(applyTrustworthinessChecks_wraps_model_output) {
+    ASSERT_EQ("Checked: candidate response", applyTrustworthinessChecks("candidate response"));
+}
+
+TEST_CASE(runSelfReview_returns_notes_for_output) {
+    ASSERT_EQ("Self-review notes for: draft", runSelfReview("draft"));
+}
+
+TEST_CASE(computeTrustScore_returns_default_value) {
+    ASSERT_NEAR(0.95f, computeTrustScore("note"), 1e-6);
+}

--- a/test/unit/test_model_backend.cpp
+++ b/test/unit/test_model_backend.cpp
@@ -1,0 +1,17 @@
+#include <string>
+
+#include "model_backend.h"
+#include "test_framework.h"
+
+TEST_CASE(run_model_returns_stitched_output) {
+    ModelBackend backend;
+    ASSERT_EQ("Model output for: hello", backend.run_model("hello"));
+}
+
+TEST_CASE(run_model_preserves_input_text) {
+    ModelBackend backend;
+    const std::string input = "safety constraints";
+    const std::string output = backend.run_model(input);
+
+    ASSERT_TRUE(output.find(input) != std::string::npos);
+}


### PR DESCRIPTION
### Motivation
- Provide a standalone, source-based C++ test project so core components can be validated without external runtime dependencies.
- Add lightweight native test tooling to enable both unit tests and BDD-style scenarios for fast, local verification of behavior.

### Description
- Added a new `test/` CMake project that builds two test executables (`prismquanta_unit_tests` and `prismquanta_native_bdd_tests`) and registers them with CTest via `test/CMakeLists.txt`.
- Introduced a tiny, header-only test harness (`test/test_framework.h`) and a shared test runner (`test/test_main.cpp`) that provide `TEST_CASE`, `ASSERT_*`, and a registry-based runner.
- Added native BDD helpers in `test/native_bdd.h` and BDD scenarios for `CoreEngine` in `test/bdd/test_core_engine_bdd.cpp` to express behavior-driven checks.
- Added unit tests covering `ethics_logic`, `model_backend`, and `core_engine` in `test/unit/` to validate expected outputs and determinism.

### Testing
- Configured and generated build files with `cmake -S test -B build/test` and the step completed successfully.
- Built the test binaries with `cmake --build build/test` and both executables were produced without compilation errors.
- Ran the test suite with `ctest --test-dir build/test --output-on-failure` and all registered tests passed (2/2 tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9c9cc1c008328957445607f301157)