### PR TITLE
Fix TerminalUI Compilation Errors and Header Dependencies

### DIFF
--- a/include/ux/extra_views.h
+++ b/include/ux/extra_views.h
@@ -9,6 +9,8 @@
 #include <fstream>
 #include <filesystem>
 #include <future>
+#include <thread>
+#include <chrono>
 
 namespace fs = std::filesystem;
 
@@ -139,9 +141,9 @@ private:
         });
     }
 
-    std::string status_ = "Ready";
-    bool running_ = false;
-    std::future<std::string> future_;
+    mutable std::string status_ = "Ready";
+    mutable bool running_ = false;
+    mutable std::future<std::string> future_;
     mutable int spinnerIndex_ = 0;
     const std::vector<char> spinner_ = {'|', '/', '-', '\\'};
 };

--- a/include/ux/terminal_ui.h
+++ b/include/ux/terminal_ui.h
@@ -30,3 +30,4 @@ private:
     std::string colorActive_ = "\033[1;30;47m";
     std::string colorNormal_ = "\033[0m";
     std::string colorAccent_ = "\033[1;34m";
+};

--- a/src/ux/terminal_ui.cpp
+++ b/src/ux/terminal_ui.cpp
@@ -3,6 +3,9 @@
 #include <fstream>
 #include <regex>
 #include <sstream>
+#include <iterator>
+#include <vector>
+#include <cstdio>
 
 #ifdef _WIN32
 #include <windows.h>


### PR DESCRIPTION
This PR addresses several compilation errors in the Terminal UI subsystem of PrismQuanta. The primary issue was a missing closing brace in the `TerminalUI` class definition header, which caused the compiler to misinterpret subsequent method definitions in the implementation file. Additionally, missing standard library headers in both the implementation and associated view headers were added. Errors related to illegal member modification within `const` methods in `extra_views.h` were also corrected by utilizing the `mutable` keyword where appropriate. All changes have been verified to compile and pass the full test suite.

---
*PR created automatically by Jules for task [5440846451240978191](https://jules.google.com/task/5440846451240978191) started by @drtamarojgreen*